### PR TITLE
Support naming lovelace assets, improve CLI

### DIFF
--- a/hass_deps/__main__.py
+++ b/hass_deps/__main__.py
@@ -75,8 +75,14 @@ def init(obj: TypedObj) -> None:
 @click.option("--include", type=str, multiple=True)
 @click.option("--root-is-custom-components", type=bool, is_flag=True, default=False)
 @click.argument("dependency")
-def add(obj: TypedObj, dependency: str, save: bool, asset: List[str],
-        include: List[str], root_is_custom_components: bool) -> None:
+def add(
+    obj: TypedObj,
+    dependency: str,
+    save: bool,
+    asset: List[str],
+    include: List[str],
+    root_is_custom_components: bool,
+) -> None:
     if dependency in obj.dependencies:
         click.echo(f"{dependency} is already installed")
         raise click.exceptions.Exit(1)
@@ -85,7 +91,7 @@ def add(obj: TypedObj, dependency: str, save: bool, asset: List[str],
         source=dependency,
         root_is_custom_components=root_is_custom_components,
         include=list(include) or None,
-        assets=list(asset) or None
+        assets=list(asset) or None,
     )
     lock_info = install_dependency(obj.config_dir, dep, lock_info=None)
 
@@ -106,7 +112,7 @@ def add(obj: TypedObj, dependency: str, save: bool, asset: List[str],
     is_flag=True,
 )
 @click.option(
-    '--write-lovelace-resources/--no-write-lovelace-resources',
+    "--write-lovelace-resources/--no-write-lovelace-resources",
     default=False,
 )
 def install(obj: TypedObj, force: bool, write_lovelace_resources: bool) -> None:

--- a/hass_deps/__main__.py
+++ b/hass_deps/__main__.py
@@ -71,13 +71,22 @@ def init(obj: TypedObj) -> None:
 @cli.command(help="Add a new dependency")
 @click.pass_obj
 @click.option("--save/--no-save", type=bool, default=True)
+@click.option("--asset", type=str, multiple=True)
+@click.option("--include", type=str, multiple=True)
+@click.option("--root-is-custom-components", type=bool, is_flag=True, default=False)
 @click.argument("dependency")
-def add(obj: TypedObj, dependency: str, save: bool) -> None:
+def add(obj: TypedObj, dependency: str, save: bool, asset: List[str],
+        include: List[str], root_is_custom_components: bool) -> None:
     if dependency in obj.dependencies:
         click.echo(f"{dependency} is already installed")
         raise click.exceptions.Exit(1)
 
-    dep = Dependency(source=dependency, root_is_custom_components=False, include=None)
+    dep = Dependency(
+        source=dependency,
+        root_is_custom_components=root_is_custom_components,
+        include=list(include) or None,
+        assets=list(asset) or None
+    )
     lock_info = install_dependency(obj.config_dir, dep, lock_info=None)
 
     obj.dependencies[dependency] = dep
@@ -96,7 +105,11 @@ def add(obj: TypedObj, dependency: str, save: bool) -> None:
     default=False,
     is_flag=True,
 )
-def install(obj: TypedObj, force: bool) -> None:
+@click.option(
+    '--write-lovelace-resources/--no-write-lovelace-resources',
+    default=False,
+)
+def install(obj: TypedObj, force: bool, write_lovelace_resources: bool) -> None:
     should_write_locked_dependencies = False
 
     for dependency in obj.dependencies.values():

--- a/hass_deps/dependency.py
+++ b/hass_deps/dependency.py
@@ -14,6 +14,11 @@ yaml = YAML()
 
 class Dependency(NamedTuple):
     source: str
+
+    # Directives for Lovelace
+    assets: Optional[List[str]]
+
+    # Directives for core dependencies
     root_is_custom_components: bool
     include: Optional[List[str]]
 
@@ -57,6 +62,7 @@ def load_dependencies(path: str) -> OrderedDict[str, Dependency]:
                 dep = {"source": dep}
             dependencies[dep["source"]] = Dependency(
                 source=dep["source"],
+                assets=dep.get("assets"),
                 root_is_custom_components=dep.get("root_is_custom_components", False),
                 include=dep.get("include"),
             )
@@ -70,13 +76,16 @@ def write_dependencies(path: str, dependencies: OrderedDict[str, Dependency]) ->
             str, Dict[str, Union[str, bool, List[str]]]
         ] = dependency.source
 
-        if dependency.include is not None or dependency.root_is_custom_components:
+        if dependency.include is not None or dependency.root_is_custom_components \
+                or dependency.assets is not None:
             # Has more advanced config, dump as an object
             dumpable_dep = {"source": dependency.source}
             if dependency.root_is_custom_components:
                 dumpable_dep["root_is_custom_components"] = True
             if dependency.include is not None:
                 dumpable_dep["include"] = dependency.include
+            if dependency.assets is not None:
+                dumpable_dep["assets"] = dependency.assets
 
         dumpable.append(dumpable_dep)
 

--- a/hass_deps/dependency.py
+++ b/hass_deps/dependency.py
@@ -76,8 +76,11 @@ def write_dependencies(path: str, dependencies: OrderedDict[str, Dependency]) ->
             str, Dict[str, Union[str, bool, List[str]]]
         ] = dependency.source
 
-        if dependency.include is not None or dependency.root_is_custom_components \
-                or dependency.assets is not None:
+        if (
+            dependency.include is not None
+            or dependency.root_is_custom_components
+            or dependency.assets is not None
+        ):
             # Has more advanced config, dump as an object
             dumpable_dep = {"source": dependency.source}
             if dependency.root_is_custom_components:

--- a/test/fixtures/demo-config/hass-deps.yaml
+++ b/test/fixtures/demo-config/hass-deps.yaml
@@ -16,3 +16,6 @@ dependencies:
   - https://github.com/shenxn/ha-dyson.git
   - https://github.com/nickw444/deebot-t8-hass.git
   - https://github.com/kalkih/mini-media-player.git
+  - source: https://github.com/gurbyz/power-wheel-card.git
+    assets:
+      - power-wheel-card.js


### PR DESCRIPTION
To allow power-wheel-card to be installed which has no js release, or `filename` in `hacs.json`:

```
hass-deps add https://github.com/gurbyz/power-wheel-card.git --asset power-wheel-card.js
```